### PR TITLE
Refresh token using Guzzle middleware

### DIFF
--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -128,7 +128,7 @@ abstract class Resource
      */
     protected function makeEntity(array $attributes = null): Entity
     {
-        $attributes = $attributes ?: $this->contents['data'];
+        $attributes = $attributes ?: $this->contents['data'] ?? [];
 
         $entity = (new ReflectionClass(static::class))->getShortName();
         $class = sprintf('Xingo\\IDServer\\Entities\\%s', Str::studly($entity));

--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -22,6 +22,18 @@ class User extends Resource
     }
 
     /**
+     * @return void
+     */
+    public function refreshToken()
+    {
+        $response = $this->call('PUT', 'auth/refresh');
+
+        $header = $response->getHeaderLine('Authentication');
+        $token = str_replace('Bearer ', '', $header);
+        app('idserver.manager')->setToken($token);
+    }
+
+    /**
      * @param array $attributes
      * @return Entity|UserEntity
      */

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+use Xingo\IDServer\Client\Middleware\InvalidToken;
 use Xingo\IDServer\Client\Middleware\JwtToken;
 use Xingo\IDServer\Client\Support\JsonStream;
 
@@ -46,6 +47,7 @@ class ServiceProvider extends BaseServiceProvider
         $handler = HandlerStack::create();
 
         $handler->push(new JwtToken(), 'jwt-token');
+        $handler->push(new InvalidToken(), 'jwt-invalid-token');
 
         $handler->push(Middleware::mapResponse(function (Response $response) {
             $stream = new JsonStream($response->getBody());

--- a/tests/Unit/Client/Middleware/InvalidTokenTest.php
+++ b/tests/Unit/Client/Middleware/InvalidTokenTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit\Client\Middleware;
+
+use Tests\Concerns\MockResponse;
+use Tests\TestCase;
+use Xingo\IDServer\Manager;
+
+class InvalidTokenTest extends TestCase
+{
+    use MockResponse;
+
+    /** @test */
+    function it_will_refresh_the_token_if_it_is_invalid()
+    {
+        $this->mockResponse(200, ['token_invalid']);
+        $this->mockResponse(204, [], ['Authentication' => 'Bearer valid-token']);
+        $this->mockResponse(201, ['data' => ['email' => 'john@example.com']]);
+
+        /** @var Manager $manager */
+        $manager = app('idserver.manager');
+        $manager->setToken('invalid-token');
+
+        $user = $manager->users->create([]);
+
+        $this->assertEquals('valid-token', $manager->getToken());
+        $this->assertEquals('john@example.com', $user->email);
+    }
+}

--- a/tests/Unit/Resources/UsersTest.php
+++ b/tests/Unit/Resources/UsersTest.php
@@ -147,4 +147,14 @@ class UsersTest extends TestCase
         $this->assertNotEmpty($jwt = session()->get(Manager::TOKEN_NAME));
         $this->assertEquals($jwt, $user->jwtToken());
     }
+
+    /** @test */
+    function it_can_refresh_the_jwt()
+    {
+        $this->mockResponse(200, [], ['Authentication' => 'Bearer new-token']);
+
+        $this->manager->users->refreshToken();
+
+        $this->assertEquals('new-token', $this->manager->getToken());
+    }
 }


### PR DESCRIPTION
> ⚠️ The PR #6 should be merged first!

Using a Guzzle middleware we can check the response. If it says the token is invalid then we refresh the token and call the same endpoint again.

🎉 🎈😄  It works! The JWT is refreshed using a Guzzle middleware.

The method `InvalidTokenTest::it_will_refresh_the_token_if_it_is_invalid()` has the whole logic to refresh a JWT.

1. We try to call an endpoint;
2. The JWT is invalid but still can be refreshed;
3. A `{"invalid_token"}` is returned;
4. Using the `InvalidToken` Guzzle middleware we verify that;
5. The token is refreshed by the middleware;
6. The same endpoint is called again, now with the new JWT.