### PR TITLE
Update password endpoints

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -47,6 +47,7 @@ class Manager
 
     /**
      * Get the JWT token which is used to connect to the IDServer
+     *
      * @return string
      */
     public function getToken(): string

--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -163,10 +163,23 @@ class User extends Resource
      * @param string $password
      * @return bool
      */
-    public function changePassword(string $token, string $password): bool
+    public function updatePassword(string $token, string $password): bool
     {
         $response = $this->call('PATCH', "users/{$this->id}/update-password", [
             'token' => $token,
+            'password' => $password,
+        ]);
+
+        return 204 === $response->getStatusCode();
+    }
+
+    /**
+     * @param string $password
+     * @return bool
+     */
+    public function changePassword(string $password): bool
+    {
+        $response = $this->call('PATCH', "users/{$this->id}/change-password", [
             'password' => $password,
         ]);
 

--- a/tests/Unit/Resources/UsersTest.php
+++ b/tests/Unit/Resources/UsersTest.php
@@ -341,7 +341,7 @@ class UsersTest extends TestCase
         $this->mockResponse(204);
 
         $result = $this->manager->users(3)
-            ->changePassword('fake-token', 'abc123');
+            ->updatePassword('fake-token', 'abc123');
 
         $this->assertTrue($result);
 
@@ -351,6 +351,25 @@ class UsersTest extends TestCase
             $this->assertEquals(http_build_query([
                 'token' => 'fake-token',
                 'password' => 'abc123',
+            ]), $request->getBody());
+        });
+    }
+
+    /** @test */
+    function it_can_change_the_password()
+    {
+        $this->mockResponse(204);
+
+        $result = $this->manager->users(4)
+            ->changePassword('secret');
+
+        $this->assertTrue($result);
+
+        $this->assertRequest(function (Request $request) {
+            $this->assertEquals('PATCH', $request->getMethod());
+            $this->assertEquals('users/4/change-password', $request->getUri()->getPath());
+            $this->assertEquals(http_build_query([
+                'password' => 'secret',
             ]), $request->getBody());
         });
     }


### PR DESCRIPTION
This PR updates the last changes made in the API to make sure `update-password` and `change-password` are different routes.

- The method `updatePassword()` is for users resetting their passwords;
- The method `changePassword()` is for logged users changing their passwords.