### PR TITLE
Implemented CLI mode for the SDK

### DIFF
--- a/config/idserver.php
+++ b/config/idserver.php
@@ -53,6 +53,45 @@ return [
 
         'secret_key' => env('IDSERVER_SECRET_KEY'),
 
+        /*
+        |--------------------------------------------------------------------------
+        | CLI Authentication
+        |--------------------------------------------------------------------------
+        |
+        | Each Store can also authenticate in CLI mode. This mode is to allow calls
+        | without being logged in as a specific user. For example to retrieve a
+        | list of users for a specified subscription in a job.
+        |
+        */
+
+        'cli' => [
+
+            /*
+            |--------------------------------------------------------------------------
+            | CLI Client ID
+            |--------------------------------------------------------------------------
+            |
+            | The CLI Client ID is used to identify the Store making the call to the
+            | API in CLI mode. It's a required value when running in CLI mode.
+            |
+            */
+
+            'client_id' => env('IDSERVER_CLI_CLIENT_ID'),
+
+            /*
+            |--------------------------------------------------------------------------
+            | CLI Secret Key
+            |--------------------------------------------------------------------------
+            |
+            | This is the key associated with the "CLI Client ID". Both field should
+            | match.
+            |
+            */
+
+            'secret_key' => env('IDSERVER_CLI_SECRET_KEY'),
+
+        ],
+
     ],
 
     /*
@@ -69,8 +108,8 @@ return [
     */
 
     'classes' => [
-//        \Xingo\IDServer\Entities\User::class => App\Entities\User::class,
-//        \Xingo\IDServer\Entities\Subscription::class => App\Entities\Subscription::class,
+        //        \Xingo\IDServer\Entities\User::class => App\Entities\User::class,
+        //        \Xingo\IDServer\Entities\Subscription::class => App\Entities\Subscription::class,
     ],
 
 ];

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -48,4 +48,14 @@ class Manager
     {
         return $this->client;
     }
+
+    /**
+     * Run the manager in CLI mode.
+     *
+     * @return Manager
+     */
+    public function asCli()
+    {
+        return app('idserver.cli.manager');
+    }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -26,6 +26,14 @@ class ServiceProvider extends BaseServiceProvider
         $this->app->singleton('idserver.manager', function (Application $app) {
             return new Manager($app->make('idserver.client'));
         });
+
+        $this->app->singleton('idserver.cli.client', function (Application $app) {
+            return new Client($this->cliOptions($app));
+        });
+
+        $this->app->singleton('idserver.cli.manager', function (Application $app) {
+            return new Manager($app->make('idserver.cli.client'));
+        });
     }
 
     /**
@@ -44,10 +52,49 @@ class ServiceProvider extends BaseServiceProvider
      */
     protected function options(Application $app): array
     {
-        $handler = HandlerStack::create();
+        $handler = $this->getHandlerConfig();
 
         $handler->push(new JwtToken(), 'jwt-token');
         $handler->push(new TokenExpired(), 'jwt-token-expired');
+
+        return [
+            'base_uri' => $this->getClientBaseUri($app),
+            'handler' => $handler,
+            'headers' => [
+                'X-XINGO-Client-ID' => $app['config']->get('idserver.store.client_id'),
+                'X-XINGO-Secret-Key' => $app['config']->get('idserver.store.secret_key'),
+            ],
+        ];
+    }
+
+    /**
+     * Get the CLI client options.
+     *
+     * @param Application $app
+     * @return array
+     */
+    protected function cliOptions(Application $app): array
+    {
+        $handler = $this->getHandlerConfig();
+
+        return [
+            'base_uri' => $this->getClientBaseUri($app),
+            'handler' => $handler,
+            'headers' => [
+                'X-XINGO-Client-ID' => $app['config']->get('idserver.store.cli.client_id'),
+                'X-XINGO-Secret-Key' => $app['config']->get('idserver.store.cli.secret_key'),
+            ],
+        ];
+    }
+
+    /**
+     * Get the handler config setup.
+     *
+     * @return HandlerStack
+     */
+    protected function getHandlerConfig(): HandlerStack
+    {
+        $handler = HandlerStack::create();
 
         $handler->push(Middleware::mapResponse(function (Response $response) {
             $stream = new JsonStream($response->getBody());
@@ -55,13 +102,17 @@ class ServiceProvider extends BaseServiceProvider
             return $response->withBody($stream);
         }));
 
-        return [
-            'base_uri' => trim($app['config']->get('idserver.url'), '/') . '/',
-            'handler' => $handler,
-            'headers' => [
-                'X-XINGO-Client-ID' => $app['config']->get('idserver.store.client_id'),
-                'X-XINGO-Secret-Key' => $app['config']->get('idserver.store.secret_key'),
-            ],
-        ];
+        return $handler;
+    }
+
+    /**
+     * Get the client base uri.
+     *
+     * @param Application $app
+     * @return string
+     */
+    protected function getClientBaseUri(Application $app): string
+    {
+        return trim($app['config']->get('idserver.url'), '/') . '/';
     }
 }

--- a/tests/Concerns/MockResponse.php
+++ b/tests/Concerns/MockResponse.php
@@ -84,6 +84,7 @@ trait MockResponse
     {
         $client = new Client(['handler' => $this->createHandler($response)]);
         app()->instance('idserver.client', $client);
+        app()->instance('idserver.cli.client', $client);
 
         $this->manager = new Manager($client);
         app()->instance('idserver.manager', $this->manager);

--- a/tests/Unit/ManagerTest.php
+++ b/tests/Unit/ManagerTest.php
@@ -71,6 +71,20 @@ class ManagerTest extends TestCase
         $this->assertInstanceOf(Resource::class, ids()->users);
     }
 
+    /** @test */
+    function it_can_run_in_cli_mode()
+    {
+        $manager = app('idserver.manager');
+
+        $manager = $manager->asCli();
+        $headers = $manager->client()->getConfig('headers');
+
+        $this->assertInstanceOf(Manager::class, $manager);
+        $this->assertInstanceOf(Resource::class, $manager->users);
+        $this->assertEquals('bar', $headers['X-XINGO-Client-ID']);
+        $this->assertEquals('foo', $headers['X-XINGO-Secret-Key']);
+    }
+
     /**
      * @param Application $app
      */
@@ -80,5 +94,7 @@ class ManagerTest extends TestCase
 
         $app['config']->set('idserver.store.client_id', 'foo');
         $app['config']->set('idserver.store.secret_key', 'bar');
+        $app['config']->set('idserver.store.cli.client_id', 'bar');
+        $app['config']->set('idserver.store.cli.secret_key', 'foo');
     }
 }

--- a/tests/Unit/Resources/UsersTest.php
+++ b/tests/Unit/Resources/UsersTest.php
@@ -9,7 +9,6 @@ use Tests\TestCase;
 use Xingo\IDServer\Entities\Address;
 use Xingo\IDServer\Entities\User;
 use Xingo\IDServer\Exceptions;
-use Xingo\IDServer\Manager;
 use Xingo\IDServer\Resources\Collection;
 
 class UsersTest extends TestCase
@@ -484,6 +483,31 @@ class UsersTest extends TestCase
             $this->assertEquals(http_build_query([
                 'password' => 'secret',
             ]), $request->getBody());
+        });
+    }
+
+
+    /** @test */
+    function it_can_get_a_user_in_cli_mode()
+    {
+        $this->mockResponse(200, [
+            'data' => [
+                'id' => 1,
+                'email' => 'john@example.com',
+            ],
+        ]);
+
+        $user = $this->manager->asCli()
+            ->users(1)
+            ->get();
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertEquals('john@example.com', $user->email);
+        $this->assertEquals(1, $user->id);
+
+        $this->assertRequest(function (Request $request) {
+            $this->assertEquals('GET', $request->getMethod());
+            $this->assertEquals('users/1', $request->getUri()->getPath());
         });
     }
 }


### PR DESCRIPTION
I've implemented the CLI mode for the SDK. It's basically only swapping the guzzle client which is now sending the CLI credentials instead of the default store credentials and not using the JWT middleware.