### PR TITLE
Update user reset password action receiving an email too

### DIFF
--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -222,7 +222,9 @@ class User extends Resource
      */
     private function userIdentifierField($identifier): string
     {
-        return is_int($identifier) ?
-            'id' : 'email';
+        /** @var \Illuminate\Validation\Validator $validator */
+        $validator = validator([$identifier], ['email']);
+
+        return $validator->passes() ? 'email' : 'id';
     }
 }

--- a/tests/Unit/Resources/UsersTest.php
+++ b/tests/Unit/Resources/UsersTest.php
@@ -474,8 +474,8 @@ class UsersTest extends TestCase
     {
         $this->mockResponse(204);
 
-        $result = $this->manager->users(3)
-            ->updatePassword(10, 'fake-token', 'abc123');
+        $result = $this->manager->users
+            ->updatePassword('10', 'fake-token', 'abc123');
 
         $this->assertTrue($result);
 


### PR DESCRIPTION
This PR updates the SDK code to match https://github.com/PH-F/idserver/pull/15.

```php
ids()->users->resetPassword('foo@bar.com');
ids()->users->updatePassword('foo@bar.com', 'token', 'new-password');
```

It accepts ID as integer or string as well:

```php
ids()->users->resetPassword(10);
ids()->users->resetPassword('10');
```