### PR TITLE
Make Entity base class implementing ArrayAccess interface

### DIFF
--- a/src/Entities/Entity.php
+++ b/src/Entities/Entity.php
@@ -2,6 +2,7 @@
 
 namespace Xingo\IDServer\Entities;
 
+use ArrayAccess;
 use Carbon\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
@@ -9,7 +10,7 @@ use Illuminate\Database\Eloquent\JsonEncodingException;
 use JsonSerializable;
 use Xingo\IDServer\Contracts\IdsEntity;
 
-abstract class Entity implements Arrayable, IdsEntity, Jsonable, JsonSerializable
+abstract class Entity implements ArrayAccess, Arrayable, IdsEntity, Jsonable, JsonSerializable
 {
     /**
      * @var array
@@ -104,6 +105,44 @@ abstract class Entity implements Arrayable, IdsEntity, Jsonable, JsonSerializabl
                 return $value;
             }
         }, $this->attributes);
+    }
+
+    /**
+     * @param mixed $offset
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->attributes[$offset]);
+    }
+
+    /**
+     * @param mixed $offset
+     * @return mixed|null
+     */
+    public function offsetGet($offset)
+    {
+        return $this->getAttribute($offset);
+    }
+
+    /**
+     * @param mixed $offset
+     * @param mixed $value
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->attributes = array_merge(
+            $this->attributes,
+            $this->convert([$offset => $value])
+        );
+    }
+
+    /**
+     * @param mixed $offset
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->attributes[$offset]);
     }
 
     /**

--- a/tests/Unit/Entities/EntityTest.php
+++ b/tests/Unit/Entities/EntityTest.php
@@ -129,4 +129,25 @@ class EntityTest extends TestCase
         $this->assertStringStartsWith('{', $json);
         $this->assertInternalType('array', json_decode($json, true));
     }
+
+    /** @test */
+    public function it_implements_array_access_interface()
+    {
+        $this->mockResponse(200, [
+            'data' => [
+                'foo' => 'Foo Bar',
+                'created_at' => '2017-12-31',
+                'store' => [
+                    'name' => 'Foo Store',
+                ],
+            ],
+        ]);
+
+        $entity = $this->manager->subscriptions(1)->get();
+
+        $this->assertEquals('Foo Bar', $entity['foo']);
+        $this->assertInstanceOf(Carbon::class, $entity['created_at']);
+        $this->assertInstanceOf(Entities\Store::class, $entity['store']);
+        $this->assertEquals('Foo Store', $entity['store']->name);
+    }
 }


### PR DESCRIPTION
This PR adds the necessary methods to make sure the `Entity` class is implementing `ArrayAccess` interface. Then we can use it as an array:

```php
$user = ids()->users(1)->get();
echo $user['first_name'];
```