### PR TITLE
Allow to filter on all possible fields

### DIFF
--- a/src/Concerns/FilteredQuery.php
+++ b/src/Concerns/FilteredQuery.php
@@ -13,7 +13,6 @@ trait FilteredQuery
     protected function queryString(array $filters): array
     {
         $organizer = $this->organizerQuery();
-        $filters = array_only($filters, static::$filters ?? []);
 
         return array_merge($filters, $organizer);
     }

--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -19,20 +19,6 @@ class User extends Resource
     use FilteredQuery;
 
     /**
-     * @var array
-     */
-    protected static $filters = [
-        'ids',
-        'role',
-        'name',
-        'first_name',
-        'last_name',
-        'username',
-        'birth',
-        'status',
-    ];
-
-    /**
      * @param string $email
      * @param string $password
      * @return IdsEntity


### PR DESCRIPTION
This PR will allow filtering from the SDK on all fields rather then limiting this through the API. It's quite some work to add a filter now. First we have to define it in the API and afterwards also in the SDK. It's a bit more secure so that we can scope the filters in the SDK, but I'm not sure if we need this kind of filtering yet in the SDK.

Please correct me if I'm wrong and forget about something.