### PR TITLE
Add new claims array to be sent to the login action

### DIFF
--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -21,11 +21,12 @@ class User extends Resource
     /**
      * @param string $email
      * @param string $password
+     * @param array $claims
      * @return IdsEntity
      */
-    public function login(string $email, string $password): IdsEntity
+    public function login(string $email, string $password, array $claims = []): IdsEntity
     {
-        $this->call('POST', 'auth/login', compact('email', 'password'));
+        $this->call('POST', 'auth/login', compact('email', 'password', 'claims'));
 
         app('idserver.manager')->setToken($this->contents['token']);
 

--- a/tests/Unit/Resources/UsersTest.php
+++ b/tests/Unit/Resources/UsersTest.php
@@ -256,6 +256,25 @@ class UsersTest extends TestCase
     }
 
     /** @test */
+    public function it_can_send_a_claims_array_to_the_login_endpoint()
+    {
+        $this->mockResponse(200, ['token' => 'bar']);
+
+        $this->manager->users
+            ->login('john@example.com', 'secret', [
+                'foo' => true,
+            ]);
+
+        $this->assertRequest(function (Request $request) {
+            $this->assertEquals(http_build_query([
+                'email' => 'john@example.com',
+                'password' => 'secret',
+                'claims' => ['foo' => true],
+            ]), (string)$request->getBody());
+        });
+    }
+
+    /** @test */
     public function it_checks_for_login_with_401_status()
     {
         $this->mockResponse(401, ['data' => []]);


### PR DESCRIPTION
This PR allows us to send a `$claims` array with some custom claims to the IDServer API login action.

This can be useful to restrict user roles, for example, `'admin' => true`, would allow only admin users to log in.

```php
public function login(string $email, string $password, array $claims = []): IdsEntity
{
    $this->call('POST', 'auth/login', compact('email', 'password', 'claims'));

    app('idserver.manager')->setToken($this->contents['token']);

    return $this->makeEntity();
}
```

Test case: `it_can_send_a_claims_array_to_the_login_endpoint()`