### PR TITLE
Fix isset/unset support

### DIFF
--- a/src/Concerns/Entity/JsonArraySupport.php
+++ b/src/Concerns/Entity/JsonArraySupport.php
@@ -56,37 +56,69 @@ trait JsonArraySupport
     }
 
     /**
-     * @param mixed $offset
+     * Determine if the given attribute exists.
+     *
+     * @param  mixed  $offset
      * @return bool
      */
     public function offsetExists($offset)
     {
-        return isset($this->$offset);
+        return ! is_null($this->getAttribute($offset));
     }
 
     /**
-     * @param mixed $offset
-     * @return mixed|null
+     * Get the value for a given offset.
+     *
+     * @param  mixed  $offset
+     * @return mixed
      */
     public function offsetGet($offset)
     {
-        return $this->$offset;
+        return $this->getAttribute($offset);
     }
 
     /**
-     * @param mixed $offset
-     * @param mixed $value
+     * Set the value for a given offset.
+     *
+     * @param  mixed  $offset
+     * @param  mixed  $value
+     * @return void
      */
     public function offsetSet($offset, $value)
     {
-        $this->$offset = $value;
+        $this->setAttribute($offset, $value);
     }
 
     /**
-     * @param mixed $offset
+     * Unset the value for a given offset.
+     *
+     * @param  mixed  $offset
+     * @return void
      */
     public function offsetUnset($offset)
     {
-        unset($this->$offset);
+        unset($this->attributes[$offset], $this->relations[$offset]);
+    }
+
+    /**
+     * Determine if an attribute or relation exists on the model.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function __isset($key)
+    {
+        return $this->offsetExists($key);
+    }
+
+    /**
+     * Unset an attribute on the model.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function __unset($key)
+    {
+        $this->offsetUnset($key);
     }
 }

--- a/tests/Unit/Entities/EntityTest.php
+++ b/tests/Unit/Entities/EntityTest.php
@@ -150,4 +150,22 @@ class EntityTest extends TestCase
         $this->assertInstanceOf(Entities\Store::class, $entity['store']);
         $this->assertEquals('Foo Store', $entity['store']->name);
     }
+    
+    /** @test */
+    public function it_can_detect_attributes_with_isset()
+    {
+        $this->mockResponse(200, [
+            'data' => [
+                'foo' => 'Bar',
+                'bar' => 'Foo',
+            ],
+        ]);
+
+        $entity = $this->manager->users(1)->get();
+
+        $this->assertTrue(isset($entity->foo));
+        $this->assertTrue(isset($entity['foo']));
+        $this->assertEquals('Bar', array_get($entity, 'foo'));
+        $this->assertEquals('Bar', data_get($entity, 'foo'));
+    }
 }


### PR DESCRIPTION
The isset support for `Entities` is broken. When calling `isset` method is returns `false` even when the attribute is set. To solve this we implemented now the Eloquent `offsetExists` and `__isset` methods.

This allows us now to call this:
```
isset($entity->foo);
isset($entity['foo'];
data_get($entity, 'foo');
array_get($entity, 'foo');
```

All of those methods were broken.