### PR TITLE
IDS-145: Make possible to disable pagination

### DIFF
--- a/src/Concerns/ResourceOrganizer.php
+++ b/src/Concerns/ResourceOrganizer.php
@@ -20,12 +20,18 @@ trait ResourceOrganizer
     protected $sortBy;
 
     /**
-     * @param int $page
+     * @param int|boolean $page
      * @param int $perPage
      * @return $this
      */
-    public function paginate(int $page = 1, int $perPage = 10)
+    public function paginate($page = 1, int $perPage = 10)
     {
+        // Disable pagination
+        if (false === $page) {
+            $page = 1;
+            $perPage = -1;
+        }
+
         $this->page = $page;
         $this->perPage = $perPage;
 

--- a/tests/Unit/Resources/ResourceTest.php
+++ b/tests/Unit/Resources/ResourceTest.php
@@ -203,6 +203,29 @@ class ResourceTest extends TestCase
     }
 
     /** @test */
+    public function it_allows_to_disable_pagination_when_necessary()
+    {
+        $this->mockResponse(200, [
+            'data' => [
+                ['id' => 1],
+                ['id' => 2],
+            ],
+        ]);
+
+        $collection = $this->manager->users
+            ->paginate(false)
+            ->all();
+
+        $this->assertCount(2, $collection);
+
+        $this->assertRequest(function (Request $request) {
+            $this->assertEquals('GET', $request->getMethod());
+            $this->assertEquals('users', $request->getUri()->getPath());
+            $this->assertEquals('page=1&per_page=-1', $request->getUri()->getQuery());
+        });
+    }
+
+    /** @test */
     public function it_can_be_sorted()
     {
         $this->mockResponse(200);


### PR DESCRIPTION
This PR changes the `paginate()` method to make possible to disable the pagination, sending `page=1&per_page=-1` as query string.