### PR TITLE
SDK filter update

### DIFF
--- a/src/Concerns/FilteredQuery.php
+++ b/src/Concerns/FilteredQuery.php
@@ -14,6 +14,6 @@ trait FilteredQuery
     {
         $organizer = $this->organizerQuery();
 
-        return array_merge($filters, $organizer);
+        return array_merge(['filter' => $filters], $organizer);
     }
 }

--- a/tests/Unit/Resources/GridTest.php
+++ b/tests/Unit/Resources/GridTest.php
@@ -66,7 +66,7 @@ class GridTest extends TestCase
         $this->assertRequest(function (Request $request) {
             $this->assertEquals('GET', $request->getMethod());
             $this->assertEquals('grids/users', $request->getUri()->getPath());
-            $this->assertEquals('name=Foo&page=2&per_page=1', $request->getUri()->getQuery());
+            $this->assertEquals('filter%5Bname%5D=Foo&page=2&per_page=1', $request->getUri()->getQuery());
         });
     }
 

--- a/tests/Unit/Resources/TagTest.php
+++ b/tests/Unit/Resources/TagTest.php
@@ -115,7 +115,7 @@ class TagTest extends TestCase
         $this->assertRequest(function (Request $request) {
             $this->assertEquals('GET', $request->getMethod());
             $this->assertEquals('tags', $request->getUri()->getPath());
-            $this->assertEquals('name=fo&page=1&per_page=10', $request->getUri()->getQuery());
+            $this->assertEquals('filter%5Bname%5D=fo&page=1&per_page=10', $request->getUri()->getQuery());
         });
     }
 }

--- a/tests/Unit/Resources/UserTest.php
+++ b/tests/Unit/Resources/UserTest.php
@@ -184,7 +184,7 @@ class UserTest extends TestCase
             $this->assertEquals('users', $request->getUri()->getPath());
 
             $this->assertEquals(
-                'first_name=foo&username=bar&page=1&per_page=10',
+                'filter%5Bfirst_name%5D=foo&filter%5Busername%5D=bar&page=1&per_page=10',
                 $request->getUri()->getQuery()
             );
         });


### PR DESCRIPTION
Use the new filtering in the SDK as described in PH-F/idserver#206. This can only be merged when the API is updated on all live environments.